### PR TITLE
Applying strip() to bytes object fails

### DIFF
--- a/helpers/shm-cleanup.py
+++ b/helpers/shm-cleanup.py
@@ -339,7 +339,7 @@ def do_scan(dev_shm_prefix, lsof):
 	while True:
 		line = lsof_process.stdout.readline()
 		if line != b'':
-			m = firstLevelDevShmRegex.search(line.strip())
+			m = firstLevelDevShmRegex.search(str(line).strip())
 			if m:
 				inuse_shm_entities.add(m.group(1))
 		else:


### PR DESCRIPTION
Just convert a bytes object to string as applying "strip()" to a bytes objects fails (OS Alma Linux 9.2, python 3.9.18)